### PR TITLE
Update rust keepass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.1"
 authors = ["Marcin Skarbek <git@skarbek.name>"]
 
 [dependencies]
-keepass = "0.1.2"
+keepass = "0.4.5"
 rust-ini = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "summon-keepass"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Marcin Skarbek <git@skarbek.name>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple [summon](https://conjurinc.github.io/summon/) provider that allows usage 
 Installation
 -----
 
-Download the tar file from the [latest release](releases), extract it and provide the executable to summon ([as per their docs](https://github.com/cyberark/summon/blob/master/provider/README.md)). Placing it in `/usr/local/lib/summon` is the easiest method.
+Download the tar file from the [latest release](../../releases), extract it and provide the executable to summon ([as per their docs](https://github.com/cyberark/summon/blob/master/provider/README.md)). Placing it in `/usr/local/lib/summon` is the easiest method.
 
 Create `.summon-keepass.ini` file in your `$HOME` directory with the following content:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Simple [summon](https://conjurinc.github.io/summon/) provider that allows usage 
 Installation
 -----
 
+Download the tar file from the [latest release](releases), extract it and provide the executable to summon ([as per their docs](https://github.com/cyberark/summon/blob/master/provider/README.md)). Placing it in `/usr/local/lib/summon` is the easiest method.
+
 Create `.summon-keepass.ini` file in your `$HOME` directory with the following content:
 
     [keepass_db]

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Let's say you have the following entries in your `secrets.yml` file:
     AWS_ACCESS_KEY_ID: !var aws/iam/user/robot/access_key_id
     AWS_SECRET_ACCESS_KEY: !var aws/iam/user/robot/secret_access_key
 
-`summon-keepass` will split each secret with `/` and then return password from database entry when username match last part of the secret and is placed in correct group determined by previous parts of the secret.
+`summon-keepass` will split each secret with `/` and then return the password from the database entry whose title matches the last part of the secret and is placed in correct group determined by previous parts of the secret.
 
 In that case Keepass database should look like this:
-![Keepass example](http://i.imgur.com/WwkYYSG.png)
+![Keepass example](https://imgur.com/SPdha3h.png)
 
 Todo
 ----

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,13 @@ extern crate ini;
 extern crate keepass;
 
 use ini::Ini;
-use keepass::{Database, OpenDBError};
+use keepass::{Database, Node, Result};
 use std::env;
 use std::fs::File;
 use std::process;
 use std::io::{self, Write};
 
-fn main() {
+fn main() -> Result<()> {
     let stdout = io::stdout();
     let mut out_handle = stdout.lock();
     let stderr = io::stderr();
@@ -28,37 +28,17 @@ fn main() {
     let keepass_db_path = keepass_db.get("path").unwrap();
     let keepass_db_pass = keepass_db.get("pass").unwrap();
 
-    let mut pass_path = args[1].to_str().unwrap().split("/").collect::<Vec<&str>>();
+    let pass_path = args[1].to_str().unwrap().split("/").collect::<Vec<&str>>();
 
-    let db = File::open(std::path::Path::new(keepass_db_path))
-                 .map_err(|e| OpenDBError::from(e))
-                 .and_then(|mut db_file| Database::open(&mut db_file, keepass_db_pass))
-                 .unwrap();
+    let path = std::path::Path::new(keepass_db_path);
+    let db = Database::open(&mut File::open(path)?, Some(keepass_db_pass), None)?;
 
-    let mut current_group = &db.root;
-    let mut current_path = pass_path.remove(0);
-
-    loop {
-        if pass_path.len() == 0 {
-            for entry in &current_group.entries {
-                if entry.get_username().unwrap() == current_path {
-                    out_handle.write(entry.get_password().unwrap().as_bytes()).unwrap();
-                    out_handle.flush().unwrap();
-                    process::exit(0);
-                }
-            }
-            err_handle.write(format!("{} could not be retrieved", args[1].to_str().unwrap()).as_bytes()).unwrap();
-            err_handle.flush().unwrap();
-            process::exit(1);
-        }
-        else {
-            for group in &current_group.child_groups {
-                if group.name == current_path {
-                    current_group = group;
-                    break;
-                }
-            }
-            current_path = pass_path.remove(0);
-        }
+    if let Some(Node::Entry(e)) = db.root.get(&pass_path) {
+	out_handle.write(e.get_password().unwrap().as_bytes()).unwrap();
+	out_handle.flush().unwrap();
+	process::exit(0);
     }
+    err_handle.write(format!("{} could not be retrieved", args[1].to_str().unwrap()).as_bytes()).unwrap();
+    err_handle.flush().unwrap();
+    process::exit(1);
 }


### PR DESCRIPTION
Hi there,

I came across your summon provider for keepass and couldn't get it working with a fresh keepass database. Updating the keepass dependency did the trick, but it required a bit of rejigging.

The new API for the library makes deep access pretty easy, but it searches based on title, not username. For this reason, I've changed the code (and the README) to reflect this and bumped the minor version as this change will affect the end user.

I'm not a rust developer by any stretch, so I'd appreciate any feedback or changes as necessary. Alternatively, if you'd rather not accept the changes at all, no hard feelings!

As I'm on macOS, I wasn't able to use the built version attached to the previous release. If you're interested in including one for a new release, I've [tagged a release](https://github.com/andrewbridge/summon-keepass/releases/tag/v0.2.0) on my fork with a macOS version of the tar (using the same structure as yours).

Cheers